### PR TITLE
fix circle orientation in makeHoles

### DIFF
--- a/Tools/MagicPanels/MagicPanels.py
+++ b/Tools/MagicPanels/MagicPanels.py
@@ -2677,7 +2677,7 @@ def makeHoles(iObj, iFace, iCylinders):
 		holeSketch = body.newObject('Sketcher::SketchObject','Sketch')
 		holeSketch.MapMode = 'FlatFace'
 
-		axis = o.Placement.Rotation.Axis
+		axis = FreeCAD.Vector(0, 0, 1)
 		circleGeo = Part.Circle(FreeCAD.Vector(0, 0, 0), axis, o.Radius)
 		holeSketch.addGeometry(circleGeo, False)
 		


### PR DESCRIPTION
The orientation of Hole sketchs circles when making drill operations in XZ and YZ planes by woodworking tools is wrong.
This change places the circles of sketchs in their correct orientation.
I will post a message in freecad forum [https://forum.freecadweb.org/viewtopic.php?f=22&t=21127&start=100](url)