### PR TITLE
Fix grain text visibility and orientation

### DIFF
--- a/Tools/grainH.py
+++ b/Tools/grainH.py
@@ -5,6 +5,44 @@ import MagicPanels
 MagicPanels.initConfig()
 translate = FreeCAD.Qt.translate
 
+
+def faceTextRotation(face):
+	"""Rotation that lays the text on the face plane with reading direction
+	(local +X) along the face's longest edge."""
+	try:
+		z = FreeCAD.Vector(face.normalAt(0.5, 0.5))
+		if z.Length < 1e-6:
+			return FreeCAD.Rotation()
+		z.normalize()
+	except:
+		return FreeCAD.Rotation()
+	longest = None
+	longestLen = 0.0
+	for e in face.Edges:
+		if e.Length > longestLen:
+			longestLen = e.Length
+			longest = e
+	if longest is None or len(longest.Vertexes) < 2:
+		return FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), z)
+	x = longest.Vertexes[-1].Point.sub(longest.Vertexes[0].Point)
+	if x.Length < 1e-6:
+		return FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), z)
+	x.normalize()
+	d = x.dot(z)
+	x = FreeCAD.Vector(x.x - z.x * d, x.y - z.y * d, x.z - z.z * d)
+	if x.Length < 1e-6:
+		return FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), z)
+	x.normalize()
+	y = z.cross(x)
+	m = FreeCAD.Matrix(
+		x.x, y.x, z.x, 0,
+		x.y, y.y, z.y, 0,
+		x.z, y.z, z.z, 0,
+		0,   0,   0,   1,
+	)
+	return FreeCAD.Placement(m).Rotation
+
+
 try:
 
 	objects = FreeCADGui.Selection.getSelection()
@@ -16,14 +54,9 @@ try:
 	i = 0
 	for o in objects:
 
-		rotated = MagicPanels.isRotated(o)
-		if rotated:
-			angle = o.Placement.Rotation.Angle
-			o.Placement.Rotation.Angle = 0
-
 		faces = subObjects[i].SubObjects
 		i = i + 1
-		
+
 		if not hasattr(o, "Grain"):
 			info = translate("grainH", "face grain direction, h - horizontal, v - vertical, x - no grain")
 			o.addProperty("App::PropertyStringList", "Grain", "Woodworking", info)
@@ -35,108 +68,55 @@ try:
 			for f in o.Shape.Faces:
 				grain.append("x")
 
+		txt = None
 		for face in faces:
 
 			faceIndex = MagicPanels.getFaceIndex(o, face)
-			[ plane, faceType ] = MagicPanels.getFaceDetails(o, face)
-			sink = MagicPanels.getFaceSink(o, face)
 
-			p = FreeCAD.Placement()
-			p.Base = face.CenterOfMass
+			rotation = faceTextRotation(face)
+			fontSize = max(math.sqrt(face.Area)/6, 20)
+			# Push origin down along text-local -Y so the glyph is vertically centred.
+			offset = rotation.multVec(FreeCAD.Vector(0, -fontSize * 0.4, 0))
+			p = FreeCAD.Placement(face.CenterOfMass.add(offset), rotation)
 
-			if plane == "XY":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(0.00, 0.00, 1.00), 0.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-1.00, 0.00, 0.00), 180.00)
-					
-			if plane == "YX":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(0.00, 0.00, 1.00), 90.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.71, -0.71, 0.00), 180.00)
-				
-			if plane == "XZ":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(1.00, 0.00, 0.00), 270.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(1.00, 0.00, 0.00), 90.00)
+			# remove any previous grain label for this face
+			for suffix in ("Grain Horizontal", "Grain Vertical", "No Grain"):
+				label = str(o.Label) + ", Face" + str(faceIndex) + ", " + suffix + " "
+				try:
+					for rmo in FreeCAD.ActiveDocument.getObjectsByLabel(label):
+						FreeCAD.ActiveDocument.removeObject(rmo.Name)
+				except:
+					pass
 
-			if plane == "ZX":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.58, -0.58, -0.58), 120.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-58.00, 58.00, -58.00), 240.00)
-
-			if plane == "YZ":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(0.58, 0.58, 0.58), 120.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.58, -0.58, 0.58), 120.00)
-
-			if plane == "ZY":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.71, 0.00, -0.71), 180.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.71, 0.00, 0.71), 180.00)
-
-			try:
-				label = str(o.Label) + ", " + "Face" + str(faceIndex) + ", " + "Grain Horizontal" + " "
-				rmo = FreeCAD.ActiveDocument.getObjectsByLabel(label)[0]
-				FreeCAD.ActiveDocument.removeObject(str(rmo.Name))
-			except:
-				skip = 1
-				
-			try:
-				label = str(o.Label) + ", " + "Face" + str(faceIndex) + ", " + "Grain Vertical" + " "
-				rmo = FreeCAD.ActiveDocument.getObjectsByLabel(label)[0]
-				FreeCAD.ActiveDocument.removeObject(str(rmo.Name))
-			except:
-				skip = 1
-			
-			try:
-				label = str(o.Label) + ", " + "Face" + str(faceIndex) + ", " + "No Grain" + " "
-				rmo = FreeCAD.ActiveDocument.getObjectsByLabel(label)[0]
-				FreeCAD.ActiveDocument.removeObject(str(rmo.Name))
-			except:
-				skip = 1
-			
-			arrows = u'\u2190' + "\n" + u'\u2192'
+			arrows = "<--H-->"
 			txt = Draft.make_text(arrows, placement=p)
-			txt.Label = str(o.Label) + ", " + "Face" + str(faceIndex) + ", " + "Grain Horizontal" + " "
-			
-			txt.ViewObject.FontSize = math.sqrt(face.Area)/6
-			txt.ViewObject.Justification = "Center"
-			txt.ViewObject.TextColor = (1.0, 0.0, 0.0, 0.0)
-			try:
-				txt.ViewObject.FontName = "FreeSans"
-			except:
-				skip = 1
+			txt.Label = str(o.Label) + ", Face" + str(faceIndex) + ", Grain Horizontal "
 
-			targetX = o.Name + ".Shape.Face" + str(faceIndex) + ".CenterOfMass.x"
-			targetY = o.Name + ".Shape.Face" + str(faceIndex) + ".CenterOfMass.y"
-			targetZ = o.Name + ".Shape.Face" + str(faceIndex) + ".CenterOfMass.z"
-			txt.setExpression('.Placement.Base.x', targetX)
-			txt.setExpression('.Placement.Base.y', targetY)
-			txt.setExpression('.Placement.Base.z', targetZ)
-			
+			txt.ViewObject.FontSize = fontSize
+			txt.ViewObject.Justification = "Center"
+			txt.ViewObject.TextColor = (0.0, 0.0, 0.0, 1.0)
+
+			centerExpr = o.Name + ".Shape.Face" + str(faceIndex) + ".CenterOfMass"
+			txt.setExpression('.Placement.Base.x', centerExpr + ".x + (" + str(offset.x) + ")")
+			txt.setExpression('.Placement.Base.y', centerExpr + ".y + (" + str(offset.y) + ")")
+			txt.setExpression('.Placement.Base.z', centerExpr + ".z + (" + str(offset.z) + ")")
+
+			try:
+				MagicPanels.moveToFirst([ txt ], o)
+			except:
+				pass
+
 			grain[faceIndex-1] = "h"
 
 		o.Grain = grain
-		
-		if rotated:
-			o.Placement.Rotation.Angle = angle
-		
-		MagicPanels.moveToFirst([ txt ], o)
-		MagicPanels.addRotation(o, [ txt ])
-		
+
 	FreeCAD.ActiveDocument.recompute()
 	FreeCADGui.Selection.clearSelection()
 
 except:
-	
+
 	info = ""
-	
+
 	info += translate('grainH', '<b>Please select face to create horizontal grain direction description. </b><br><br><b>Note:</b> This tool creates horizontal grain direction description at selected face. You can select multiple faces and multiple objects. Hold left CTRL key during selection. The Grain attribute will be added to the object. After adding grain direction description the object can be moved and the grain description will be moved together with the object.')
 
 	MagicPanels.showInfo("grainH", info)

--- a/Tools/grainV.py
+++ b/Tools/grainV.py
@@ -5,25 +5,58 @@ import MagicPanels
 MagicPanels.initConfig()
 translate = FreeCAD.Qt.translate
 
+
+def faceTextRotation(face):
+	"""Rotation that lays the text on the face plane with reading direction
+	(local +X) along the face's longest edge."""
+	try:
+		z = FreeCAD.Vector(face.normalAt(0.5, 0.5))
+		if z.Length < 1e-6:
+			return FreeCAD.Rotation()
+		z.normalize()
+	except:
+		return FreeCAD.Rotation()
+	longest = None
+	longestLen = 0.0
+	for e in face.Edges:
+		if e.Length > longestLen:
+			longestLen = e.Length
+			longest = e
+	if longest is None or len(longest.Vertexes) < 2:
+		return FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), z)
+	x = longest.Vertexes[-1].Point.sub(longest.Vertexes[0].Point)
+	if x.Length < 1e-6:
+		return FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), z)
+	x.normalize()
+	d = x.dot(z)
+	x = FreeCAD.Vector(x.x - z.x * d, x.y - z.y * d, x.z - z.z * d)
+	if x.Length < 1e-6:
+		return FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), z)
+	x.normalize()
+	y = z.cross(x)
+	m = FreeCAD.Matrix(
+		x.x, y.x, z.x, 0,
+		x.y, y.y, z.y, 0,
+		x.z, y.z, z.z, 0,
+		0,   0,   0,   1,
+	)
+	return FreeCAD.Placement(m).Rotation
+
+
 try:
 
 	objects = FreeCADGui.Selection.getSelection()
 	subObjects = FreeCADGui.Selection.getSelectionEx()
-	
+
 	if len(objects) < 1:
 		raise
 
 	i = 0
 	for o in objects:
 
-		rotated = MagicPanels.isRotated(o)
-		if rotated:
-			angle = o.Placement.Rotation.Angle
-			o.Placement.Rotation.Angle = 0
-
 		faces = subObjects[i].SubObjects
 		i = i + 1
-		
+
 		if not hasattr(o, "Grain"):
 			info = translate("grainV", "face grain direction, h - horizontal, v - vertical, x - no grain")
 			o.addProperty("App::PropertyStringList", "Grain", "Woodworking", info)
@@ -35,108 +68,54 @@ try:
 			for f in o.Shape.Faces:
 				grain.append("x")
 
+		txt = None
 		for face in faces:
 
 			faceIndex = MagicPanels.getFaceIndex(o, face)
-			[ plane, faceType ] = MagicPanels.getFaceDetails(o, face)
-			sink = MagicPanels.getFaceSink(o, face)
 
-			p = FreeCAD.Placement()
-			p.Base = face.CenterOfMass
+			rotation = faceTextRotation(face)
+			fontSize = max(math.sqrt(face.Area)/6, 20)
+			offset = rotation.multVec(FreeCAD.Vector(0, -fontSize * 0.4, 0))
+			p = FreeCAD.Placement(face.CenterOfMass.add(offset), rotation)
 
-			if plane == "XY":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(0.00, 0.00, 1.00), 0.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-1.00, 0.00, 0.00), 180.00)
-					
-			if plane == "YX":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(0.00, 0.00, 1.00), 90.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.71, -0.71, 0.00), 180.00)
-				
-			if plane == "XZ":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(1.00, 0.00, 0.00), 270.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(1.00, 0.00, 0.00), 90.00)
+			# remove any previous grain label for this face
+			for suffix in ("Grain Horizontal", "Grain Vertical", "No Grain"):
+				label = str(o.Label) + ", Face" + str(faceIndex) + ", " + suffix + " "
+				try:
+					for rmo in FreeCAD.ActiveDocument.getObjectsByLabel(label):
+						FreeCAD.ActiveDocument.removeObject(rmo.Name)
+				except:
+					pass
 
-			if plane == "ZX":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.58, -0.58, -0.58), 120.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-58.00, 58.00, -58.00), 240.00)
-
-			if plane == "YZ":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(0.58, 0.58, 0.58), 120.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.58, -0.58, 0.58), 120.00)
-
-			if plane == "ZY":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.71, 0.00, -0.71), 180.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.71, 0.00, 0.71), 180.00)
-
-			try:
-				label = str(o.Label) + ", " + "Face" + str(faceIndex) + ", " + "Grain Horizontal" + " "
-				rmo = FreeCAD.ActiveDocument.getObjectsByLabel(label)[0]
-				FreeCAD.ActiveDocument.removeObject(str(rmo.Name))
-			except:
-				skip = 1
-				
-			try:
-				label = str(o.Label) + ", " + "Face" + str(faceIndex) + ", " + "Grain Vertical" + " "
-				rmo = FreeCAD.ActiveDocument.getObjectsByLabel(label)[0]
-				FreeCAD.ActiveDocument.removeObject(str(rmo.Name))
-			except:
-				skip = 1
-			
-			try:
-				label = str(o.Label) + ", " + "Face" + str(faceIndex) + ", " + "No Grain" + " "
-				rmo = FreeCAD.ActiveDocument.getObjectsByLabel(label)[0]
-				FreeCAD.ActiveDocument.removeObject(str(rmo.Name))
-			except:
-				skip = 1
-
-			arrows = u'\u2191' + u'\u2193'
+			arrows = "V"
 			txt = Draft.make_text(arrows, placement=p)
-			txt.Label = str(o.Label) + ", " + "Face" + str(faceIndex) + ", " + "Grain Vertical" + " "
-			
-			txt.ViewObject.FontSize = math.sqrt(face.Area)/6
-			txt.ViewObject.Justification = "Center"
-			txt.ViewObject.TextColor = (1.0, 0.0, 0.0, 0.0)
-			try:
-				txt.ViewObject.FontName = "FreeSans"
-			except:
-				skip = 1
+			txt.Label = str(o.Label) + ", Face" + str(faceIndex) + ", Grain Vertical "
 
-			targetX = o.Name + ".Shape.Face" + str(faceIndex) + ".CenterOfMass.x"
-			targetY = o.Name + ".Shape.Face" + str(faceIndex) + ".CenterOfMass.y"
-			targetZ = o.Name + ".Shape.Face" + str(faceIndex) + ".CenterOfMass.z"
-			txt.setExpression('.Placement.Base.x', targetX)
-			txt.setExpression('.Placement.Base.y', targetY)
-			txt.setExpression('.Placement.Base.z', targetZ)
-			
+			txt.ViewObject.FontSize = fontSize
+			txt.ViewObject.Justification = "Center"
+			txt.ViewObject.TextColor = (0.0, 0.0, 0.0, 1.0)
+
+			centerExpr = o.Name + ".Shape.Face" + str(faceIndex) + ".CenterOfMass"
+			txt.setExpression('.Placement.Base.x', centerExpr + ".x + (" + str(offset.x) + ")")
+			txt.setExpression('.Placement.Base.y', centerExpr + ".y + (" + str(offset.y) + ")")
+			txt.setExpression('.Placement.Base.z', centerExpr + ".z + (" + str(offset.z) + ")")
+
+			try:
+				MagicPanels.moveToFirst([ txt ], o)
+			except:
+				pass
+
 			grain[faceIndex-1] = "v"
 
 		o.Grain = grain
-		
-		if rotated:
-			o.Placement.Rotation.Angle = angle
-		
-		MagicPanels.moveToFirst([ txt ], o)
-		MagicPanels.addRotation(o, [ txt ])
 
 	FreeCAD.ActiveDocument.recompute()
 	FreeCADGui.Selection.clearSelection()
 
 except:
-	
+
 	info = ""
-	
+
 	info += translate('grainV', '<b>Please select face to create vertical grain direction description. </b><br><br><b>Note:</b> This tool creates vertical grain direction description at selected face. You can select multiple faces and multiple objects. Hold left CTRL key during selection. The Grain attribute will be added to the object. After adding grain direction description the object can be moved and the grain description will be moved together with the object.')
 
 	MagicPanels.showInfo("grainV", info)

--- a/Tools/grainX.py
+++ b/Tools/grainX.py
@@ -5,6 +5,44 @@ import MagicPanels
 MagicPanels.initConfig()
 translate = FreeCAD.Qt.translate
 
+
+def faceTextRotation(face):
+	"""Rotation that lays the text on the face plane with reading direction
+	(local +X) along the face's longest edge."""
+	try:
+		z = FreeCAD.Vector(face.normalAt(0.5, 0.5))
+		if z.Length < 1e-6:
+			return FreeCAD.Rotation()
+		z.normalize()
+	except:
+		return FreeCAD.Rotation()
+	longest = None
+	longestLen = 0.0
+	for e in face.Edges:
+		if e.Length > longestLen:
+			longestLen = e.Length
+			longest = e
+	if longest is None or len(longest.Vertexes) < 2:
+		return FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), z)
+	x = longest.Vertexes[-1].Point.sub(longest.Vertexes[0].Point)
+	if x.Length < 1e-6:
+		return FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), z)
+	x.normalize()
+	d = x.dot(z)
+	x = FreeCAD.Vector(x.x - z.x * d, x.y - z.y * d, x.z - z.z * d)
+	if x.Length < 1e-6:
+		return FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), z)
+	x.normalize()
+	y = z.cross(x)
+	m = FreeCAD.Matrix(
+		x.x, y.x, z.x, 0,
+		x.y, y.y, z.y, 0,
+		x.z, y.z, z.z, 0,
+		0,   0,   0,   1,
+	)
+	return FreeCAD.Placement(m).Rotation
+
+
 try:
 
 	objects = FreeCADGui.Selection.getSelection()
@@ -16,14 +54,9 @@ try:
 	i = 0
 	for o in objects:
 
-		rotated = MagicPanels.isRotated(o)
-		if rotated:
-			angle = o.Placement.Rotation.Angle
-			o.Placement.Rotation.Angle = 0
-
 		faces = subObjects[i].SubObjects
 		i = i + 1
-		
+
 		if not hasattr(o, "Grain"):
 			info = translate("grainX", "face grain direction, h - horizontal, v - vertical, x - no grain")
 			o.addProperty("App::PropertyStringList", "Grain", "Woodworking", info)
@@ -35,108 +68,54 @@ try:
 			for f in o.Shape.Faces:
 				grain.append("x")
 
+		txt = None
 		for face in faces:
 
 			faceIndex = MagicPanels.getFaceIndex(o, face)
-			[ plane, faceType ] = MagicPanels.getFaceDetails(o, face)
-			sink = MagicPanels.getFaceSink(o, face)
 
-			p = FreeCAD.Placement()
-			p.Base = face.CenterOfMass
+			rotation = faceTextRotation(face)
+			fontSize = max(math.sqrt(face.Area)/6, 20)
+			offset = rotation.multVec(FreeCAD.Vector(0, -fontSize * 0.4, 0))
+			p = FreeCAD.Placement(face.CenterOfMass.add(offset), rotation)
 
-			if plane == "XY":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(0.00, 0.00, 1.00), 0.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-1.00, 0.00, 0.00), 180.00)
-					
-			if plane == "YX":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(0.00, 0.00, 1.00), 90.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.71, -0.71, 0.00), 180.00)
-				
-			if plane == "XZ":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(1.00, 0.00, 0.00), 270.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(1.00, 0.00, 0.00), 90.00)
+			# remove any previous grain label for this face
+			for suffix in ("Grain Horizontal", "Grain Vertical", "No Grain"):
+				label = str(o.Label) + ", Face" + str(faceIndex) + ", " + suffix + " "
+				try:
+					for rmo in FreeCAD.ActiveDocument.getObjectsByLabel(label):
+						FreeCAD.ActiveDocument.removeObject(rmo.Name)
+				except:
+					pass
 
-			if plane == "ZX":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.58, -0.58, -0.58), 120.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-58.00, 58.00, -58.00), 240.00)
-
-			if plane == "YZ":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(0.58, 0.58, 0.58), 120.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.58, -0.58, 0.58), 120.00)
-
-			if plane == "ZY":
-				if sink == "-":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.71, 0.00, -0.71), 180.00)
-				if sink == "+":
-					p.Rotation = FreeCAD.Rotation(FreeCAD.Vector(-0.71, 0.00, 0.71), 180.00)
-
-			try:
-				label = str(o.Label) + ", " + "Face" + str(faceIndex) + ", " + "Grain Horizontal" + " "
-				rmo = FreeCAD.ActiveDocument.getObjectsByLabel(label)[0]
-				FreeCAD.ActiveDocument.removeObject(str(rmo.Name))
-			except:
-				skip = 1
-				
-			try:
-				label = str(o.Label) + ", " + "Face" + str(faceIndex) + ", " + "Grain Vertical" + " "
-				rmo = FreeCAD.ActiveDocument.getObjectsByLabel(label)[0]
-				FreeCAD.ActiveDocument.removeObject(str(rmo.Name))
-			except:
-				skip = 1
-			
-			try:
-				label = str(o.Label) + ", " + "Face" + str(faceIndex) + ", " + "No Grain" + " "
-				rmo = FreeCAD.ActiveDocument.getObjectsByLabel(label)[0]
-				FreeCAD.ActiveDocument.removeObject(str(rmo.Name))
-			except:
-				skip = 1
-
-			arrows = "No Grain"
+			arrows = "X"
 			txt = Draft.make_text(arrows, placement=p)
-			txt.Label = str(o.Label) + ", " + "Face" + str(faceIndex) + ", " + "No Grain" + " "
-			
-			txt.ViewObject.FontSize = math.sqrt(face.Area)/6
-			txt.ViewObject.Justification = "Center"
-			txt.ViewObject.TextColor = (1.0, 0.0, 0.0, 0.0)
-			try:
-				txt.ViewObject.FontName = "FreeSans"
-			except:
-				skip = 1
+			txt.Label = str(o.Label) + ", Face" + str(faceIndex) + ", No Grain "
 
-			targetX = o.Name + ".Shape.Face" + str(faceIndex) + ".CenterOfMass.x"
-			targetY = o.Name + ".Shape.Face" + str(faceIndex) + ".CenterOfMass.y"
-			targetZ = o.Name + ".Shape.Face" + str(faceIndex) + ".CenterOfMass.z"
-			txt.setExpression('.Placement.Base.x', targetX)
-			txt.setExpression('.Placement.Base.y', targetY)
-			txt.setExpression('.Placement.Base.z', targetZ)
-			
+			txt.ViewObject.FontSize = fontSize
+			txt.ViewObject.Justification = "Center"
+			txt.ViewObject.TextColor = (0.0, 0.0, 0.0, 1.0)
+
+			centerExpr = o.Name + ".Shape.Face" + str(faceIndex) + ".CenterOfMass"
+			txt.setExpression('.Placement.Base.x', centerExpr + ".x + (" + str(offset.x) + ")")
+			txt.setExpression('.Placement.Base.y', centerExpr + ".y + (" + str(offset.y) + ")")
+			txt.setExpression('.Placement.Base.z', centerExpr + ".z + (" + str(offset.z) + ")")
+
+			try:
+				MagicPanels.moveToFirst([ txt ], o)
+			except:
+				pass
+
 			grain[faceIndex-1] = "x"
 
 		o.Grain = grain
-		
-		if rotated:
-			o.Placement.Rotation.Angle = angle
-
-		MagicPanels.moveToFirst([ txt ], o)
-		MagicPanels.addRotation(o, [ txt ])
 
 	FreeCAD.ActiveDocument.recompute()
 	FreeCADGui.Selection.clearSelection()
 
 except:
-	
+
 	info = ""
-	
+
 	info += translate('grainX', '<b>Please select face to create direction description about no grain. </b><br><br><b>Note:</b> This tool creates direction description  about no grain at selected face. You can select multiple faces and multiple objects. Hold left CTRL key during selection. The Grain attribute will be added to the object. After adding grain direction description the object can be moved and the grain description will be moved together with the object.')
 
 	MagicPanels.showInfo("grainX", info)


### PR DESCRIPTION
## Summary

The `grainH` / `grainV` / `grainX` tools place a Draft Text label on the selected face to indicate the chosen grain direction. In FreeCAD 1.x the label is effectively invisible or mis-oriented on most panels. This PR fixes the three root causes.

## Problems

1. **Invisible text** — `txt.ViewObject.TextColor = (1.0, 0.0, 0.0, 0.0)` sets the alpha channel to 0. On FreeCAD versions that honour the RGBA tuple, the text renders fully transparent.
2. **Missing glyphs** — `FontName = "FreeSans"` is enforced via `try`/`except`. When FreeSans exists but does not include the arrow glyphs (`←` `→` `↑` `↓`), the arrows render as empty boxes / nothing. Users see only ASCII characters mixed in (verified by typing `↑↓A` and seeing only `A`).
3. **Wrong rotation** — the placement rotation is computed by:
   - temporarily zeroing the panel rotation (`o.Placement.Rotation.Angle = 0`),
   - looking up a hardcoded rotation per `(plane, sink)` combination from `getFaceDetails` / `getFaceSink`,
   - restoring the panel rotation,
   - then calling `MagicPanels.addRotation(o, [txt])` which multiplies quaternions on top.

   The result is unreliable for any non-canonical panel placement, e.g. panels with a rotation already applied, panels on YZ-style faces, etc.

## Fix

- **`TextColor = (0.0, 0.0, 0.0, 1.0)`** (opaque black) on all three tools.
- **Replace Unicode arrows with ASCII tokens** that render with the default font everywhere:
  - `grainH` → `<--H-->`
  - `grainV` → `V`
  - `grainX` → `X`
- **Remove the `FontName = "FreeSans"` block** — let the user's default font take over.
- **Compute placement directly from face geometry**:
  - `+Z` axis = `face.normalAt(0.5, 0.5)` (perpendicular to the face).
  - `+X` axis = direction of the face's longest edge, projected into the face plane (reading direction along the long side of the panel).
  - `+Y` axis = `Z × X` (closes a right-handed orthonormal basis).
  - Built into a `FreeCAD.Matrix` and converted to a `Placement` rotation.
- **Drop the `isRotated` / `Angle = 0` / `addRotation` workaround** — no longer needed.
- **Vertical centring offset** — Draft Text anchors at the baseline, so the glyph centre sits ~0.4·FontSize above the placement origin. Shift `Placement.Base` along the text-local -Y axis by `0.4 * FontSize`, folded into the `setExpression` bindings so the label stays centred when the face moves.
- **`FontSize` floor** of 20 so small faces still show readable labels.

## Test plan

- [ ] On a `Part::Box` panel oriented along world axes, select the big face and run `grainH` → black `<--H-->` along the long edge, centred.
- [ ] Same on a panel rotated 45° in `Placement.Rotation` → label still on the face plane, oriented along the long edge.
- [ ] Same on a face whose normal is `+X` (YZ-style cara) → label still readable from the +X direction, centred.
- [ ] `grainV` shows `V`, `grainX` shows `X`, both centred.
- [ ] Move the panel: label follows the face centre via `setExpression`.